### PR TITLE
Fix parsing of User-Agent in extended log format

### DIFF
--- a/apachelog.py
+++ b/apachelog.py
@@ -131,7 +131,7 @@ class parser:
         subpatterns = []
 
         findquotes = re.compile(r'^\\"')
-        findreferreragent = re.compile('Referer|User-Agent')
+        findreferreragent = re.compile('Referer|User-Agent', re.I)
         findpercent = re.compile('^%.*t$')
         lstripquotes = re.compile(r'^\\"')
         rstripquotes = re.compile(r'\\"$')
@@ -265,7 +265,7 @@ formats = {
     'vhcommon':r'%v %h %l %u %t \"%r\" %>s %b',
 
     # NCSA extended/combined log format
-    'extended':r'%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"',
+    'extended':r'%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"',
     }
 
 if __name__ == '__main__':
@@ -274,8 +274,7 @@ if __name__ == '__main__':
     class TestApacheLogParser(unittest.TestCase):
 
         def setUp(self):
-            self.format = r'%h %l %u %t \"%r\" %>s '\
-                          r'%b \"%{Referer}i\" \"%{User-Agent}i\"'
+            self.format = formats['extended']
             self.fields = '%h %l %u %t %r %>s %b %{Referer}i '\
                           '%{User-Agent}i'.split(' ')
             self.pattern = '^(\\S*) (\\S*) (\\S*) (\\[[^\\]]+\\]) '\


### PR DESCRIPTION
Referer and User-Agent were searched for case-sensitively, and the
extended format definition had a different case from the version being
searched for.

Originally by Guilherme Salgado in Launchpad's apachelog fork:

  http://bazaar.launchpad.net/~launchpad-pqm/launchpad/devel/revision/8269.5.3