### PR TITLE
Use raw strings for regex backslash-escapes

### DIFF
--- a/apachelog.py
+++ b/apachelog.py
@@ -148,7 +148,7 @@ class parser:
             
             self._names.append(self.alias(element))
             
-            subpattern = '(\S*)'
+            subpattern = r'(\S*)'
             
             if hasquotes:
                 if element == '%r' or findreferreragent.search(element):


### PR DESCRIPTION
Unknown backslash-escapes in ordinary strings cause a DeprecationWarning
in Python >= 3.6.  Use raw strings for these.

Found by "flake8 --select=W605".